### PR TITLE
fix first frame platform snap

### DIFF
--- a/source/objects/Platform.gml
+++ b/source/objects/Platform.gml
@@ -7,7 +7,7 @@ applies_to=self
 snap = true;
 bounce = true;
 
-platform_floor_prev = 0;
+platform_floor_prev = ternary(global.grav == 1, bbox_top, bbox_bottom);
 #define Step_0
 /*"/*'/**//* YYD ACTION
 lib_id=1

--- a/source/objects/Player.gml
+++ b/source/objects/Player.gml
@@ -22,7 +22,7 @@ x_scale = 1;
 has_bow = (save_get("difficulty") == 0);
 on_floor = false;
 vine_direction = false;
-feet_y_prev = 0;
+feet_y_prev = ternary(global.grav == 1, bbox_bottom, bbox_top);
 
 if global.save_autosave {
     save_save();


### PR DESCRIPTION
In certain scenarios, the player can snap to a platform far above or below their position. This only happens when one of the variables determining snap is still at 0 during the Player's end step platform snap detection (action 1 of end step)

Demonstration:
![image](https://github.com/iwVerve/Verve-GM82-Engine/assets/14039593/ccd959a4-8f7a-4666-b364-fc0897607cd0)
Before trigger

![image](https://github.com/iwVerve/Verve-GM82-Engine/assets/14039593/97ae376a-280b-459a-8f5b-c4cce7dc69cf)
After trigger

There's two cases that are similar but discrete.

**Snapping on recreating Player object: case 1 2 and 3**
This only happens if the player object is recreated after the player's step phase, thus resetting the player's `feet_y_prev` to 0. For example, this happens if you create a player autoreplacer and then reload.
Fastest way to forcefully reproduce this is via adding a `if keyboard_check_pressed(ord('L')) {instance_create(x,y,Player); instance_destroy()}` after the `feet_y_prev` is set in the player's step phase. 
As a result this isn't very frequent unless in complicated collab games.

Save midair between the platforms, then recreate the player

- Case 1: nothing happens
- Case 2: the player snaps to the top platform
- Case 3: the player snaps to the top platform

Setting `feet_y_prev` on create fixes these cases.

**Snapping on platform creation: case 4 5 and 6**
This can be a lot more common. If a platform is created below the player, the player will snap to it. Same idea, `platform_floor_prev` is still at 0 during the player's end step.

The second picture shows where the platforms spawn upon touching the trigger. Trigger code is simply one or two `instance_create(some_x, some_y, Platform)`

- Case 4: the player snaps to the bottom platform
- Case 5: nothing happens
- Case 6: the player snaps to the bottom platform

Setting `platform_floor_prev` on create fixes these cases.

**Context:**
The code which messes up from these is in the player's end step and looks like this: 
```game-maker-language
    // Whether the player just landed on the platform from above.
    _above_platform_prev = global.grav * (other.feet_y_prev) < global.grav * (platform_floor_prev);
    _on_or_below_platform_now = global.grav * (_feet_y) >= global.grav * (_platform_floor - global.grav);
    _landed_on_platform = _above_platform_prev && _on_or_below_platform_now;
    // Whether the player just jumped through the platform from below.
    _below_platform_prev = global.grav * (other.feet_y_prev) >= global.grav * (platform_floor_prev);
    _on_or_above_platform_now = global.grav * (_feet_y) < global.grav * (_platform_floor);
    _jumped_out = _below_platform_prev && _on_or_above_platform_now;

    if _landed_on_platform || (_jumped_out && snap) {
      // snaps to platform
``` 

For case 1,2,3 the `_above_platform_prev` is set to true when `feet_y_prev` is 0, causing `_landed_on_platform` to be true for platforms above the player.
For case 4,5,6 the `_below_platform_prev` is set to true because of `platform_floor_prev` being 0, causing `_jumped_out` to be true for platforms below the player.

